### PR TITLE
Fixed clipping in iOS tileImage() method.

### DIFF
--- a/Ports/iOSPort/nativeSources/DrawImage.m
+++ b/Ports/iOSPort/nativeSources/DrawImage.m
@@ -125,7 +125,7 @@ static GLuint getOGLProgram(){
 #if TARGET_IPHONE_SIMULATOR
     // for some lame reason, the simulator positions things just a tad different
     // than the device.  This is an attempt to play an out-of-tune piano.
-    dy=0.5;
+    dy=0;
 #endif
     
     GLfloat vertexes[] = {

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -1488,11 +1488,17 @@ public class IOSImplementation extends CodenameOneImplementation {
     public void tileImage(Object graphics, Object img, int x, int y, int w, int h) {
         NativeGraphics ng = (NativeGraphics)graphics;
         if(ng instanceof GlobalGraphics) {
+            int clipX = this.getClipX(graphics);
+            int clipY = this.getClipY(graphics);
+            int clipW = this.getClipWidth(graphics);
+            int clipH = this.getClipHeight(graphics);
+            this.clipRect(graphics, x, y, w, h);
             ng.checkControl();
             ng.applyTransform();
             ng.applyClip();
             NativeImage nm = (NativeImage)img;
             nativeInstance.nativeTileImageGlobal(nm.peer, ng.alpha, x, y, w, h);
+            this.setClip(graphics, clipX, clipY, clipW, clipH);
         } else {
             super.tileImage(graphics, img, x, y, w, h);
         }


### PR DESCRIPTION
This seems to fix the clipping issue with tileImage() on iOS.
